### PR TITLE
Correcao links podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ Esse projeto está sob licença. Veja o arquivo [LICENÇA](LICENSE.md) para mais
         </sub>
       </a><br>
     </td>
+    <td align="center">
+      <a href="https://github.com/jomrs">
+        <img src="https://avatars.githubusercontent.com/u/47464761" width="100px;" alt="Foto do Jonhtan Mota no Github"/><br>
+        <sub>
+          <b>Jonhtan Mota</b>
+        </sub>
+      </a><br>
+    </td>
     </tr>
   </tr>
 </table>

--- a/pages/materiais-gratuitos-para-estudos.br.md
+++ b/pages/materiais-gratuitos-para-estudos.br.md
@@ -118,8 +118,8 @@
 
 | Link      | Idioma | Link      | Idioma |
 | ---------- | :------: | ---------- | :------: |
-| [Cabeça de Lab](https://hipsters.tech/assinar/) | <img src="../flags/br.jpg" width="40px">| [UXPodcast](https://uxpodcast.com/episodes/) | <img src="../flags/eua.png" width="40px"> |
-| [Hipsters.Tech](https://datahackers.com.br/podcast) | <img src="../flags/br.jpg" width="40px"> | [The Changelog](https://changelog.com/podcasts) | <img src="../flags/eua.png" width="40px"> |
+| [Cabeça de Lab](https://www.cabecadelab.com.br/) | <img src="../flags/br.jpg" width="40px">| [UXPodcast](https://uxpodcast.com/episodes/) | <img src="../flags/eua.png" width="40px"> |
+| [Hipsters.Tech](https://www.hipsters.tech/assinar/) | <img src="../flags/br.jpg" width="40px"> | [The Changelog](https://changelog.com/podcasts) | <img src="../flags/eua.png" width="40px"> |
 | [Data Hackers](https://datahackers.com.br/podcast) | <img src="../flags/br.jpg" width="40px"> | [IdeaCast](https://hbr.org/2018/01/podcast-ideacast) | <img src="../flags/eua.png" width="40px"> |
 | [Dev na Estrada](https://devnaestrada.com.br/) | <img src="../flags/br.jpg" width="40px"> | [Modern CTO](https://moderncto.io/podcast/)| <img src="../flags/eua.png" width="40px"> |
 | [Estratégia Tech](https://anchor.fm/estrategia-tech) | <img src="../flags/br.jpg" width="40px"> | [The Longcut](https://open.spotify.com/show/6i0Cr3VgOSpN7lMZHV9eJR) | <img src="../flags/eua.png" width="40px"> |


### PR DESCRIPTION
Curti demais o repositório, mas notei que os links na seção do podcast da versão br estavam mandando para outros podcasts. Alterei os links agora devem corretos, os afetados que vi foram os podcasts:

- Cabeça de Lab;
- Hipsters.Tech;